### PR TITLE
Coerce data.tables to data.frame

### DIFF
--- a/Codes/translateCountryCode.R
+++ b/Codes/translateCountryCode.R
@@ -14,6 +14,8 @@
 translateCountryCode = function (data, from, to, oldCode)
 {
     cat("\nNOTE: Please make sure that the country are matched according to their definition\n\n")
+    if(is(data, "data.table"))
+        data = data.frame(data)
     if (missing(oldCode))
         oldCode = from
     if (from != to) {


### PR DESCRIPTION
Currently, if you pass a data.table in the data argument, some later functionality doesn't work properly.  In particular, on line 26:
if(any(is.na(trans.df[, to])))
If data is a data.table, trans.df will be a data.table.  Then, trans.df[, to] will evaluate to the character string to, and it won't ever be NA.  The easiest fix (in my mind) is to just check the type at the beginning and coerce the passed dataset to a data.frame if it's not already.