### PR TITLE
Minor warning from install_github: "Username parameter is deprecated"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ version can be installed by specifying the **ref** argument.
 
 ```r
 library(devtools)
-install_github(repo = "FAOSTATpackage", username = "mkao006", subdir = "FAOSTAT")
+install_github(repo = "mkao006/FAOSTATpackage", subdir = "FAOSTAT")
 ```
 
 Vignettes and demos are available and please make use of them:


### PR DESCRIPTION
Recommended installation code:

    library(devtools)
    install_github(repo = "FAOSTATpackage", username = "mkao006", subdir = "FAOSTAT")

Returned the warning: 

    Warning message:
    Username parameter is deprecated. Please use mkao006/FAOSTATpackage 

install_github() call was changed to 

    install_github(repo = "mkao006/FAOSTATpackage",subdir = "FAOSTAT")